### PR TITLE
atomsに汎用的なimgを、moleculesに汎用的なロゴコンポーネントを定義

### DIFF
--- a/src/component/atoms/img/ImgAtoms.tsx
+++ b/src/component/atoms/img/ImgAtoms.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+interface ImgProps {
+  img_src: string; // 画像のソースを指定するプロパティ
+  style?: React.CSSProperties; // インラインスタイルを受け取るプロパティ
+  alt?: string; // 画像のalt属性を指定するプロパティ
+  className?: string;
+}
+
+const ImgAtoms: React.FC<ImgProps> = ({ img_src, style, alt, className }) => {
+  return <img src={img_src} alt={alt} className={className} style={style} />;
+};
+
+export default ImgAtoms;

--- a/src/component/atoms/img/__tests__/imgAtoms.test.tsx
+++ b/src/component/atoms/img/__tests__/imgAtoms.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react';
+import ImgAtoms from '../ImgAtoms';
+
+describe('Logo component', () => {
+  // img_srcが提供された場合に画像がレンダリングされることを確認
+  it('should render an image when img_src is provided', () => {
+    const imageSrc = 'https://example.com/logo.png';
+    render(<ImgAtoms img_src={imageSrc} />);
+    // 画像要素が表示されていることを確認
+    const imgElement = screen.getByRole('img');
+    expect(imgElement).toBeInTheDocument();
+    expect(imgElement).toHaveAttribute('src', imageSrc);
+  });
+
+  // styleプロパティを介して渡されたカスタムスタイルが適用されることを確認
+  it('should apply custom styles passed via the style prop', () => {
+    const customStyle = { color: 'red', fontSize: '2rem' };
+    render(<ImgAtoms img_src="" style={customStyle} />);
+    // style属性が適用されていることを確認
+    const imgElement = screen.getByRole('img');
+    expect(imgElement).toHaveStyle(customStyle);
+  });
+
+  // altプロパティを介して渡されたaltが適用されることを確認
+  it('should apply alt passed via the style prop', () => {
+    const alt = 'custom-alt';
+    render(<ImgAtoms img_src="" alt={alt} />);
+    // alt属性が適用されていることを確認
+    const imgElement = screen.getByAltText(alt);
+    expect(imgElement).toBeInTheDocument();
+  });
+});

--- a/src/component/molecules/logo/ImgLogo.tsx
+++ b/src/component/molecules/logo/ImgLogo.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import ImgAtoms from '../../atoms/img/ImgAtoms';
+
+interface LogoProps {
+  img_src: string; // 画像のソースを指定するプロパティ
+  style?: React.CSSProperties; // インラインスタイルを受け取るプロパティ
+  alt?: string; // 画像のalt属性を指定するプロパティ
+}
+
+const ImgLogo: React.FC<LogoProps> = ({ img_src, style, alt }) => {
+  return (
+    <ImgAtoms
+      img_src={img_src}
+      alt={alt ?? 'Logo'}
+      className={'image-logo'}
+      style={{ ...style, maxHeight: '50px', marginRight: '10px' }}
+    />
+  );
+};
+
+export default ImgLogo;

--- a/src/component/molecules/logo/__tests__/imgLogo.test.tsx
+++ b/src/component/molecules/logo/__tests__/imgLogo.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from '@testing-library/react';
+import ImgLogo from '../ImgLogo';
+
+describe('Logo component', () => {
+  it('should render an image when img_src is provided', () => {
+    const imageSrc = 'https://example.com/logo.png';
+    render(<ImgLogo img_src={imageSrc} alt="Logo" />);
+    // 画像要素が表示されていることを確認
+    const imgElement = screen.getByRole('img');
+    expect(imgElement).toBeInTheDocument();
+    expect(imgElement).toHaveAttribute('src', imageSrc);
+    expect(imgElement).toHaveAttribute('alt', 'Logo');
+  });
+
+  it('should apply custom styles passed via the style prop', () => {
+    const customStyle = {
+      color: 'red',
+      fontSize: '2rem',
+    };
+    render(<ImgLogo img_src="" alt="Logo" style={customStyle} />);
+    // style属性が適用されていることを確認
+    const logoElement = screen.getByAltText('Logo');
+    expect(logoElement).toHaveStyle(customStyle);
+  });
+
+  it('should apply alt passed via the style prop', () => {
+    const alt = 'custom-alt';
+    render(<ImgLogo img_src="" alt={alt} />);
+    // style属性が適用されていることを確認
+    const logoElement = screen.getByAltText(alt);
+    expect(logoElement).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
単体テストは全て通している