### PR TITLE
molecules層にcheckboxを均等に配置したgridを定義。

### DIFF
--- a/src/component/molecules/checkboxGrid/CheckboxGrid.tsx
+++ b/src/component/molecules/checkboxGrid/CheckboxGrid.tsx
@@ -1,0 +1,43 @@
+// molecules/CheckboxGrid.tsx
+import React from 'react';
+import Checkbox from '../../atoms/checkbox/CheckboxAtoms';
+
+interface CheckboxOption {
+  label: string;
+  checked: boolean;
+  disabled?: boolean;
+}
+
+interface CheckboxGridProps {
+  options: CheckboxOption[];
+  onChange: (index: number, checked: boolean) => void;
+  columns?: number;
+}
+
+const CheckboxGrid: React.FC<CheckboxGridProps> = ({
+  options,
+  onChange,
+  columns = 3, // Default to 3 columns
+}) => {
+  return (
+    <div
+      className="grid gap-4"
+      style={{
+        display: 'grid',
+        gridTemplateColumns: `repeat(${columns}, minmax(0, 1fr))`,
+      }}
+    >
+      {options.map((option, index) => (
+        <Checkbox
+          key={index}
+          label={option.label}
+          checked={option.checked}
+          disabled={option.disabled}
+          onChange={(checked) => onChange(index, checked)}
+        />
+      ))}
+    </div>
+  );
+};
+
+export default CheckboxGrid;

--- a/src/component/molecules/checkboxGrid/__tests__/CheckboxGrid.test.tsx
+++ b/src/component/molecules/checkboxGrid/__tests__/CheckboxGrid.test.tsx
@@ -1,0 +1,90 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import CheckboxGrid from '../CheckboxGrid';
+
+describe('CheckboxGrid Component', () => {
+  const mockOptions = [
+    { label: 'Option 1', checked: false },
+    { label: 'Option 2', checked: true },
+    { label: 'Option 3', checked: false, disabled: true },
+  ];
+
+  const mockOnChange = jest.fn();
+
+  // チェックボックスの個数が正しいことを確認
+  test('renders the correct number of checkboxes', () => {
+    render(
+      <CheckboxGrid
+        options={mockOptions}
+        onChange={mockOnChange}
+        columns={2}
+      />,
+    );
+
+    const checkboxes = screen.getAllByTestId('checkbox-input');
+    expect(checkboxes).toHaveLength(mockOptions.length);
+  });
+
+  // チェックボックスの各ラベルが正しく表示されることを確認
+  test('renders the labels correctly', () => {
+    render(
+      <CheckboxGrid
+        options={mockOptions}
+        onChange={mockOnChange}
+        columns={2}
+      />,
+    );
+
+    mockOptions.forEach((option) => {
+      expect(screen.getByText(option.label)).toBeInTheDocument();
+    });
+  });
+
+  // チェックボックスがクリックされたときに、正しくonChangeが呼び出されることを確認
+  test('calls onChange with the correct arguments when a checkbox is clicked', () => {
+    render(
+      <CheckboxGrid
+        options={mockOptions}
+        onChange={mockOnChange}
+        columns={2}
+      />,
+    );
+
+    const checkbox = screen.getAllByTestId('checkbox-input')[0];
+    fireEvent.click(checkbox);
+
+    expect(mockOnChange).toHaveBeenCalledWith(0, true);
+  });
+
+  // オプションに基づいてチェックボックスを正しく無効にすることを確認
+  test('disables checkboxes correctly based on the options', () => {
+    render(
+      <CheckboxGrid
+        options={mockOptions}
+        onChange={mockOnChange}
+        columns={2}
+      />,
+    );
+
+    const checkboxes = screen.getAllByTestId('checkbox-input');
+
+    expect(checkboxes[0]).not.toBeDisabled();
+    expect(checkboxes[1]).not.toBeDisabled();
+    expect(checkboxes[2]).toBeDisabled();
+  });
+
+  // columnsプロップに基づいて正しいグリッドレイアウトをレンダリングすることを確認
+  test('renders the correct grid layout based on the columns prop', () => {
+    const { container } = render(
+      <CheckboxGrid
+        options={mockOptions}
+        onChange={mockOnChange}
+        columns={3}
+      />,
+    );
+
+    const grid = container.firstChild;
+    expect(grid).toHaveStyle(
+      'grid-template-columns: repeat(3, minmax(0, 1fr))',
+    );
+  });
+});


### PR DESCRIPTION
columnsで列数を制御できる機能追加済み。
テストには、個数確認や、ラベル表示、クリック判定とdisabledの確認などが書いてある。
しかし、ロジック関係はなく、クリックされた時に変数を変更する機能は非搭載。あとで追記する必要がある。