### PR TITLE
atoms層に汎用的ボタンを追加。基礎的なテストも記載&突破済み。

### DIFF
--- a/src/component/atoms/button/ButtonAtoms.tsx
+++ b/src/component/atoms/button/ButtonAtoms.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+interface ImgProps {
+  text: string; // 画像のソースを指定するプロパティ
+  onClick: () => void; // クリックイベントを受け取るプロパティ
+  style?: React.CSSProperties; // インラインスタイルを受け取るプロパティ
+  className?: string;
+  disabled?: boolean;
+}
+
+const ButtonAtoms: React.FC<ImgProps> = ({
+  onClick,
+  style,
+  className,
+  disabled,
+}) => {
+  return (
+    <button
+      onClick={disabled ? undefined : onClick}
+      disabled={disabled} // 明示的にdisabledを適用
+      className={className}
+      style={style}
+    />
+  );
+};
+
+export default ButtonAtoms;

--- a/src/component/atoms/button/__tests__/buttonAtoms.test.tsx
+++ b/src/component/atoms/button/__tests__/buttonAtoms.test.tsx
@@ -1,0 +1,55 @@
+// ButtonAtoms.test.tsx
+import { fireEvent, render, screen } from '@testing-library/react';
+import ButtonAtoms from '../ButtonAtoms';
+
+describe('ButtonAtoms component', () => {
+  it('should call onClick handler when clicked', () => {
+    const handleClick = jest.fn();
+    render(<ButtonAtoms onClick={handleClick} text="Click Me" />);
+
+    const buttonElement = screen.getByRole('button');
+    fireEvent.click(buttonElement);
+
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not call onClick handler when disabled', () => {
+    const handleClick = jest.fn();
+    render(
+      <ButtonAtoms onClick={handleClick} text="Disabled" disabled={true} />,
+    );
+
+    const buttonElement = screen.getByRole('button');
+    fireEvent.click(buttonElement);
+
+    expect(handleClick).not.toHaveBeenCalled();
+  });
+
+  it('should apply custom styles passed via the style prop', () => {
+    const customStyle = { backgroundColor: 'red', fontSize: '16px' };
+    render(
+      <ButtonAtoms
+        onClick={() => {}}
+        text="Styled Button"
+        style={customStyle}
+      />,
+    );
+
+    const buttonElement = screen.getByRole('button');
+    expect(buttonElement).toHaveStyle(customStyle);
+  });
+
+  it('should apply custom class name passed via the className prop', () => {
+    const className = 'custom-class';
+    render(
+      <ButtonAtoms
+        onClick={() => {}}
+        text="Class Button"
+        className={className}
+      />,
+    );
+
+    const buttonElement = screen.getByRole('button');
+    expect(buttonElement).toHaveClass(className);
+  });
+});


### PR DESCRIPTION
テストの内容は、クリックが反応するか、disabledでクリックが止まるか、stylesをインラインで挿入可能かの3種類。まだまだ増える可能性はあるが、まずは簡易的に実装を行いたい。