### PR TITLE
atoms層のtextに汎用的なp要素(このプロジェクトで使い回す用)を定義。テストも定義済み。

### DIFF
--- a/src/component/atoms/text/Paragraph.tsx
+++ b/src/component/atoms/text/Paragraph.tsx
@@ -1,0 +1,11 @@
+// Atoms/Heading.tsx
+import React from 'react';
+
+type HeadingProps = {
+  children: React.ReactNode;
+  className?: string;
+};
+
+export const Paragraph: React.FC<HeadingProps> = ({ children, className }) => (
+  <p className={className}>{children}</p>
+);

--- a/src/component/atoms/text/__tests__/paragraph.test.tsx
+++ b/src/component/atoms/text/__tests__/paragraph.test.tsx
@@ -1,0 +1,34 @@
+// Atoms/Paragraph.test.tsx
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { Paragraph } from './../Paragraph';
+
+describe('Paragraph Component', () => {
+  it('renders the correct children', () => {
+    render(<Paragraph>Hello World</Paragraph>);
+    expect(screen.getByText('Hello World')).toBeInTheDocument();
+  });
+
+  it('renders as a <p> tag', () => {
+    render(<Paragraph>Paragraph Test</Paragraph>);
+    const paragraph = screen.getByText('Paragraph Test');
+    expect(paragraph.tagName).toBe('P');
+  });
+
+  it('applies the correct className', () => {
+    render(<Paragraph className="custom-class">Styled Paragraph</Paragraph>);
+    const paragraph = screen.getByText('Styled Paragraph');
+    expect(paragraph).toHaveClass('custom-class');
+  });
+
+  it('renders multiple children correctly', () => {
+    render(
+      <Paragraph>
+        <span>Child 1</span>
+        <span>Child 2</span>
+      </Paragraph>,
+    );
+    expect(screen.getByText('Child 1')).toBeInTheDocument();
+    expect(screen.getByText('Child 2')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
p要素のデザインを修正したい時は、atomsのpをいじれば良い。テストは全て突破済み。