### PR TITLE
ローカルストレージを用いたキャッシュReactQueryを定義。

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "platform",
       "version": "0.1.0",
       "dependencies": {
+        "@tanstack/query-sync-storage-persister": "^5.62.7",
+        "@tanstack/react-query": "^5.62.7",
+        "@tanstack/react-query-persist-client": "^5.62.7",
         "@types/highcharts": "^5.0.44",
         "@types/node": "^16.18.119",
         "@types/react": "^18.3.12",
@@ -3581,6 +3584,76 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/gregberge"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.62.7",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.62.7.tgz",
+      "integrity": "sha512-fgpfmwatsrUal6V+8EC2cxZIQVl9xvL7qYa03gsdsCy985UTUlS4N+/3hCzwR0PclYDqisca2AqR1BVgJGpUDA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/query-persist-client-core": {
+      "version": "5.62.7",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-persist-client-core/-/query-persist-client-core-5.62.7.tgz",
+      "integrity": "sha512-9HcaD9rEp2nGWnrw2osK5UCSKJbJKEdn+MEhVVfnUPSFN7MZFpFZxpRCHJi3fRpWOYsVeH9EFODX+aoJaniJMA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.62.7"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/query-sync-storage-persister": {
+      "version": "5.62.7",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-sync-storage-persister/-/query-sync-storage-persister-5.62.7.tgz",
+      "integrity": "sha512-fcXCT65VgmgKsSM5XfRlk0hXnQMpkHLCMpOjqq7Rl2DMjHZcKjtgSEw+drHZBggJ5dqAhPd5DAcZ/utIE192nw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.62.7",
+        "@tanstack/query-persist-client-core": "5.62.7"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.62.7",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.62.7.tgz",
+      "integrity": "sha512-+xCtP4UAFDTlRTYyEjLx0sRtWyr5GIk7TZjZwBu4YaNahi3Rt2oMyRqfpfVrtwsqY2sayP4iXVCwmC+ZqqFmuw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.62.7"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-query-persist-client": {
+      "version": "5.62.7",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-persist-client/-/react-query-persist-client-5.62.7.tgz",
+      "integrity": "sha512-RmEJ3YvsK7lv1Of3CCXBgHDtoZVwHMtTKCTegZz+xijVJsgJaNNfel4YTpbQ0ydnWT2IcohdqnHUtBE6p1KCIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-persist-client-core": "5.62.7"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "^5.62.7",
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@tanstack/query-sync-storage-persister": "^5.62.7",
+    "@tanstack/react-query": "^5.62.7",
+    "@tanstack/react-query-persist-client": "^5.62.7",
     "@types/highcharts": "^5.0.44",
     "@types/node": "^16.18.119",
     "@types/react": "^18.3.12",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,12 +1,26 @@
+import { createSyncStoragePersister } from '@tanstack/query-sync-storage-persister';
+import { QueryClient } from '@tanstack/react-query';
+import { PersistQueryClientProvider } from '@tanstack/react-query-persist-client';
 import React from 'react';
 import { CookiesProvider } from 'react-cookie';
 import ReactDOM from 'react-dom/client';
-import { QueryClient, QueryClientProvider } from 'react-query';
 import { BrowserRouter } from 'react-router-dom';
 import AppRouter from './app';
 import './index.css';
 
 const queryClient = new QueryClient();
+
+// ローカルストレージを使用したPersister
+const localStoragePersister = createSyncStoragePersister({
+  storage: window.localStorage,
+});
+// Persistの設定
+export const persistOptions = {
+  queryClient,
+  persister: localStoragePersister,
+  // 必要に応じてキャッシュの有効期限を設定
+  maxAge: 1000 * 60 * 60 * 24, // 24時間
+};
 
 const root = ReactDOM.createRoot(
   document.getElementById('root') as HTMLElement,
@@ -16,11 +30,14 @@ root.render(
   <React.StrictMode>
     <BrowserRouter>
       {/* reactクエリを用いてAPIを叩く */}
-      <QueryClientProvider client={queryClient}>
+      <PersistQueryClientProvider
+        client={queryClient}
+        persistOptions={persistOptions}
+      >
         <CookiesProvider>
           <AppRouter />
         </CookiesProvider>
-      </QueryClientProvider>
+      </PersistQueryClientProvider>
     </BrowserRouter>
   </React.StrictMode>,
 );


### PR DESCRIPTION
API連携を行うときに、取得した都道府県情報などを再取得してしまわないようにローカルストレージに保管しておく。容量も小さいため不都合は少ないはずである。