### PR TITLE
都道府県に応じた人口総計を取得するAPIを定義。

### DIFF
--- a/src/interface/population.tsx
+++ b/src/interface/population.tsx
@@ -1,0 +1,16 @@
+// 人口データの型を定義
+type PopulationData = {
+  year: number;
+  value: number;
+  ratio?: number;
+};
+
+type PopulationTitle = {
+  label: string;
+  data: PopulationData[];
+};
+
+export type PopulationType = {
+  boundaryYear: number;
+  data: PopulationTitle[];
+};

--- a/src/services/api/population/useGetPopulation.tsx
+++ b/src/services/api/population/useGetPopulation.tsx
@@ -1,0 +1,78 @@
+import {
+  useQueries,
+  useQueryClient,
+  UseQueryResult,
+} from '@tanstack/react-query';
+import axios from 'axios';
+import { PopulationType } from '../../../interface/population';
+
+interface QueryState<T>
+  extends Pick<
+    UseQueryResult<T>,
+    'isLoading' | 'isError' | 'error' | 'status'
+  > {
+  data: T | undefined;
+}
+
+// Axiosクライアントの作成
+const apiClient = axios.create({
+  baseURL: process.env.REACT_APP_API_URL,
+  headers: {
+    'Content-Type': 'application/json; charset=UTF-8', // 必須ヘッダー
+  },
+});
+
+// 都道府県データを取得する関数
+const getPopulation = async (prefCode: number): Promise<PopulationType> => {
+  const response = await apiClient.get(
+    '/api/v1/population/composition/perYear?prefCode=' + prefCode,
+    {
+      headers: {
+        'X-API-KEY': process.env.REACT_APP_X_API_KEY, // X-API-KEYをヘッダーに追加
+      },
+    },
+  );
+  return response.data.result; // レスポンスデータを返却
+};
+
+// React Query用のカスタムフック
+export const useGetPopulation = (
+  prefCodes: number[],
+): QueryState<PopulationType[]> => {
+  const queryClient = useQueryClient();
+
+  const prefectureQueries = useQueries({
+    queries: prefCodes.map((prefCode) => ({
+      queryKey: ['prefecture', prefCode],
+      queryFn: () => getPopulation(prefCode),
+      // キャッシュの設定
+      staleTime: 5 * 60 * 1000, // 5分間はキャッシュを新鮮として扱う
+      cacheTime: 30 * 60 * 1000, // 30分間キャッシュを保持
+      // オプションでプリフェッチしたデータを使用
+      initialData: () => {
+        return queryClient.getQueryData(['prefecture', prefCode]);
+      },
+    })),
+  });
+
+  // 全てのクエリの状態を集約
+  const isLoading = prefectureQueries.some((query) => query.isLoading);
+  const isError = prefectureQueries.some((query) => query.isError);
+  const error = prefectureQueries.find((query) => query.error)?.error ?? null;
+  const status = isLoading ? 'pending' : isError ? 'error' : 'success';
+  // 型安全なフィルタリング処理
+  const data =
+    isLoading || isError
+      ? undefined
+      : prefectureQueries
+          .map((query) => query.data)
+          .filter((data): data is PopulationType => data !== undefined);
+
+  return {
+    data,
+    isLoading,
+    isError,
+    error,
+    status,
+  };
+};


### PR DESCRIPTION
選択中のprefcodeを配列として受け取って、ひとつ一つのprefcodeでapiを叩く。ここで、それぞれのエンドポイントに対して取得した結果は一定時間キャッシュに保存されるということを明記しておく。これによって、チェックボックスを連打したとしても、サーバーへの負荷は最小限のものとなる。これはアプリケーションの設計上必須な要件であるため、以降変更する際には意識してほしい。