### PR TITLE
populationデータをそのまま受け取って、チャート形式に直すPopulationChartコンポーネントを定義。

### DIFF
--- a/src/component/organisms/chart/PopulationChart.tsx
+++ b/src/component/organisms/chart/PopulationChart.tsx
@@ -1,0 +1,61 @@
+import Highcharts from 'highcharts';
+import HighchartsReact from 'highcharts-react-official';
+import {
+  PopulationData,
+  PopulationLabel,
+  PopulationTitle,
+  PopulationType,
+} from '../../../interface/population';
+
+interface PopulationChartProps {
+  title: string; // グラフのタイトル
+  label: PopulationLabel; // 抽出するデータのラベル
+  populationData: PopulationType[]; // 人口データ
+}
+
+const PopulationChart: React.FC<PopulationChartProps> = (props) => {
+  // データがない場合はエラーメッセージを表示
+  if (!props.populationData?.[0]?.data?.[0]?.data) {
+    return <div>データがありません</div>;
+  }
+  // ラベルに対応するカテゴリを取得。カテゴリは全てのデータで共通であることを前提としている。
+  const categories = props.populationData?.[0]?.data
+    ?.find((data: PopulationTitle) => data.label === props.label)
+    ?.data.map((data: PopulationData) => data.year);
+
+  const options = {
+    title: { text: props.title },
+    yAxis: {
+      title: {
+        text: '人口 (人)',
+      },
+    },
+    xAxis: {
+      categories: categories,
+      title: {
+        text: '年度（年）',
+      },
+    },
+    series: props.populationData
+      .map(
+        (population: PopulationType) =>
+          // ラベルに対応するデータがあれば
+          population.data?.find(
+            (data: PopulationTitle) => data.label === props.label,
+          ) && {
+            name: population.prefName,
+            data: population.data
+              // タイトルが一致するデータの人口データを取得
+              ?.find((data: PopulationTitle) => data.label === props.label)
+              // 人口データのvalueを取得
+              ?.data?.map((data: PopulationData) => data.value),
+          },
+      )
+      // APIの形式変更により予期せぬラベルが与えられた時はundefinedが含まれてtypeエラーとなるため、undefinedを除外する。
+      .filter(Boolean),
+  };
+
+  return <HighchartsReact highcharts={Highcharts} options={options} />;
+};
+
+export default PopulationChart;

--- a/src/component/templates/HomeTemplate.tsx
+++ b/src/component/templates/HomeTemplate.tsx
@@ -1,11 +1,10 @@
 // ホームのtemplatesを作成
-import Highcharts from 'highcharts';
-import HighchartsReact from 'highcharts-react-official';
 import React from 'react';
 import { PopulationType } from '../../interface/population';
 import { PrefectureType } from '../../interface/prefecture';
 import CheckboxGrid from '../molecules/checkboxGrid/CheckboxGrid';
 import ModeButtons from '../organisms/button/ModeButtons';
+import PopulationChart from '../organisms/chart/PopulationChart';
 import AppHeader from '../organisms/header/AppHeader';
 import ModeSection from '../organisms/titleSection/ModeSection';
 import PrefecturePopulationSection from '../organisms/titleSection/PrefecturePopulationSection';
@@ -18,14 +17,6 @@ interface HomeTemplateProps {
 }
 
 const HomeTemplate: React.FC<HomeTemplateProps> = (props) => {
-  const options = {
-    title: { text: '都道府県別の総人口' },
-    series: [
-      { name: '東京都', data: [10, 20, 30, 40, 50] },
-      { name: '鹿児島', data: [4, 2, 7, 8, 13] },
-    ],
-  };
-
   return (
     <div className="home-template">
       <AppHeader img_src="yumemi.png" />
@@ -35,7 +26,11 @@ const HomeTemplate: React.FC<HomeTemplateProps> = (props) => {
 
         {/* チャート部分 */}
         <section className="home-template-chart-section">
-          <HighchartsReact highcharts={Highcharts} options={options} />
+          <PopulationChart
+            title="都道府県別の総人口"
+            label={'年少人口'}
+            populationData={props.population ?? []}
+          />
         </section>
 
         {/* 表示モード選択部分 */}

--- a/src/interface/population.tsx
+++ b/src/interface/population.tsx
@@ -1,12 +1,18 @@
 // 人口データの型を定義
-type PopulationData = {
+export type PopulationData = {
   year: number;
   value: number;
   ratio?: number;
 };
 
-type PopulationTitle = {
-  label: string;
+export type PopulationLabel =
+  | '総人口'
+  | '年少人口'
+  | '生産年齢人口'
+  | '老年人口';
+
+export type PopulationTitle = {
+  label: PopulationLabel;
   data: PopulationData[];
 };
 


### PR DESCRIPTION
populationをchart形式のoptionsに直すロジックは別で定義する方がいいだろう。テストも実行しずらいし、何より可読性が悪い。api連携とCD設計が終わったあと、ロジック定義にかかる予定だから、その時にまとめて修正すると思う。